### PR TITLE
Update index.html: fix typos

### DIFF
--- a/download.osmdata.xyz/index.html
+++ b/download.osmdata.xyz/index.html
@@ -35,9 +35,9 @@ tr:nth-child(even){background-color: #f2f2f2}
     <body>
         <img src="osmdata_logo_power_wide_small.png" alt="osmdata.xyz_logo_wide_small" class="responsive" width="640" height="199">
 		<h1>Global openstreetmap data extracts | osmdata.xyz</h1>
-        <p><b>Introduction:</b> This project provides global data extracts based on <a href="https://planet.openstreetmap.org/">openstreetmap data</a> as GeoPackage. Each extract represents its related <a href="https://wiki.openstreetmap.org/wiki/Map_Featuresregarding">primary feature</a> regarding the <a href="https://www.openstreetmap.org/">openstreetmap project.</a></p>
+        <p><b>Introduction:</b> This project provides global data extracts based on <a href="https://planet.openstreetmap.org/">openstreetmap data</a> as GeoPackage. Each extract represents its related <a href="https://wiki.openstreetmap.org/wiki/Map_Features">primary feature</a> regarding the <a href="https://www.openstreetmap.org/">openstreetmap project.</a></p>
 		<p><b>Information</b> about this project and data processing: <a href="https://github.com/michaelmgis/osmdata.xyz">osmdata.xyz on github</a></p>
-		<p><b>Updates</b> are available every month. Building and Higway are updated every second month.</p>
+		<p><b>Updates</b> are available every month. Building and Highway are updated every second month.</p>
 		<hr>
 		<h2>Downloads</h2>
 		<p><b>Note:</b> The GeoPackages are compressed into ZIP-Archives. Projection of the geodata: <a href="https://spatialreference.org/ref/epsg/4326/">WGS 84 | EPSG 4326</a></p>
@@ -48,7 +48,7 @@ tr:nth-child(even){background-color: #f2f2f2}
 			<th>File</th>
 			<th>Size of ZIP<br>approx.</th>
 			<th>Size of GeoPackage<br>approx.</th>
-			<th>Last update<br>dd.mm.yyy</th>
+			<th>Last update<br>dd.mm.yyyy</th>
 		  </tr>
 		  <tr>
 			<td>Building</td>
@@ -257,7 +257,7 @@ tr:nth-child(even){background-color: #f2f2f2}
 		</div>
 <hr>
 		
-		<h3>Archive</h3>
+		<h3>Archives</h3>
 		The datasets are available on request from the following dates (dd.mm.yyyy): 
 			<ul>
 				<li>10.06.2019</li>


### PR DESCRIPTION
The last change, Archive -> Archives, might be slightly controversial, but I thought that since multiple archives are offered (upon request), plural is proper.