### PR TITLE
adds md5 file download for timestamp

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,9 @@ RUN axel -n 3 -a -v https://download.geofabrik.de/europe/germany/bremen-latest.o
     osmium tags-filter bremen-latest.osm.pbf nwr/addr:* -o pbf/bremen-latest_addr.osm.pbf &&\
     osmium tags-filter bremen-latest.osm.pbf nwr/water -o pbf/bremen-latest_water.osm.pbf
 
+#getting md5 file for timestamp
+RUN wget https://download.geofabrik.de/europe/germany/bremen-latest.osm.pbf.md5
+
 # switch USER
 USER postgres
 

--- a/docker/import_osm.sh
+++ b/docker/import_osm.sh
@@ -21,6 +21,10 @@ then
 	echo "no FTP arguments supplied"
 fi
 
+#getting file creation time:
+timestamp=$(date +%s -r /home/osmdata/bremen-latest.osm.pbf.md5)
+echo $timestamp
+
 #array=( natural office )
 array=( natural building highway landuse waterway boundary route \
 	amenity place leisure water power barrier railway man_made shop \


### PR DESCRIPTION
downloads a md5 file which still has a valid creation date after downloading it. this timestamp can be used to update the tables prior gpkg creation.